### PR TITLE
Removed response log (fixes #3)

### DIFF
--- a/cmd/ingress-healthz/main.go
+++ b/cmd/ingress-healthz/main.go
@@ -35,8 +35,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Println(string(jsonResponse))
-
 	w.Header().Set("Content-Type", "application/json")
 	if _, err := w.Write(jsonResponse); err != nil {
 		log.Println(err)


### PR DESCRIPTION
When running in an environment with many clusters this generates quite a lot of logs. In our case it generates 0.5 million logs under 4 hours. The log itself does not provide any interesting information as I see it. Removing it would make our logs much easier to browse.